### PR TITLE
Fixes an error using "require 'dijon'"

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "mvc",
     "design pattern"
   ],
+  "main": "dist/dijon.js",
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.3.0",


### PR DESCRIPTION
Using npm

```
var dijon = require("dijon");
```

It's occurred an error that is 'Cannot find module 'dijon'.
I fix it.
